### PR TITLE
Disabled the check as a workaround for this error on MacOS

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ def videodownloader(link, app):
             'outtmpl': os.path.join(download_folder, '%(title)s.%(ext)s'),
             'noplaylist': True,
             'extract_audio': not is_video,
+            'nocheckcertificate': True,
         }
 
         try:


### PR DESCRIPTION
# Pull Request: Fix SSL Certificate Verification Failed on MacOS

## Summary
This pull request introduces a workaround for the SSL certificate verification issue encountered on macOS. The `nocheckcertificate` option has been added to disable certificate checks temporarily when using the `download_thread` function. This ensures compatibility across systems while addressing the Mac-specific error.

### **Author of the Change**
The changes in this pull request were implemented by [HarenDev](https://github.com/HarenDev). Special thanks for addressing this issue and providing a quick fix!

## Changes Made
- Added the `'nocheckcertificate': True` parameter in the `download_thread` function.
- Updated the configuration to bypass SSL certificate validation on macOS.

## Motivation
The primary motivation behind this fix was to address the following error experienced by users on macOS:

- SSL: CERTIFICATE_VERIFY_FAILED


By adding this workaround, the application will now run smoothly on macOS without interruptions caused by SSL validation issues.

## Testing
- Verified the changes on macOS to confirm the issue is resolved.
- Tested on other windows to ensure no negative impact occurs.

## Checklist
- [x] Code has been tested on macOS.
- [x] Changes do not affect functionality on windows.
